### PR TITLE
Remove some white-space

### DIFF
--- a/index.js
+++ b/index.js
@@ -11,7 +11,7 @@ function parseFrontMatter(src) {
     return `export const frontMatter = ${stringifyObject(
         data,
     )};
-    
+
 ${content}`
 }
 


### PR DESCRIPTION
Small fix that allows transformation of the following (contrived example; not tested):

`index.mdx`:
```
---
name: README
route: /
---

import ReadMe from "README.md";

<ReadMe />
```

`README.md`:
```
# Some heading

...
```