### PR TITLE
Add support for frontMatterName option

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,21 +5,30 @@ const stringifyObject = require('stringify-object')
 const mdx = require('@mdx-js/mdx')
 const { process } = require('babel-jest')
 
-function parseFrontMatter(src) {
+function parseFrontMatter(src, options) {
     const { content, data } = matter(src)
+    const { frontMatterName } = options
 
-    return `export const frontMatter = ${stringifyObject(
+    return `export const ${frontMatterName ? frontMatterName : "frontMatter"} = ${stringifyObject(
         data,
     )};
 
 ${content}`
 }
 
-function createTransformer(src, ...rest) {
-    const withFrontMatter = parseFrontMatter(src)
+function createTransformer(src, filename, config, transformOptions) {
+    let options = {}
+
+    for (let i = 0; i < config.transform.length; i++) {
+        if (new RegExp(config.transform[i][0]).test(filename)) {
+            options = config.transform[i][2]
+        }
+    }
+
+    const withFrontMatter = parseFrontMatter(src, options)
     const jsx = mdx.sync(withFrontMatter)
     const toTransform = `import {mdx} from '@mdx-js/react';${jsx}`
-    return process(toTransform, ...rest).code
+    return process(toTransform, filename, config, transformOptions).code
 }
 
 module.exports = {


### PR DESCRIPTION
As mentioned in #8, this PR adds support for a `frontMatterName` option that specifies the name of the parsed frontmatter object.