### PR TITLE
Add mdxOptions for configuring remark/rehype plugins

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,9 +1,10 @@
 'use strict'
 
+const path = require("path")
 const matter = require('gray-matter')
 const stringifyObject = require('stringify-object')
 const mdx = require('@mdx-js/mdx')
-const { process } = require('babel-jest')
+const { process: babelJestProcess } = require('babel-jest')
 
 function parseFrontMatter(src, options = {}) {
     const { content, data } = matter(src)
@@ -25,10 +26,14 @@ function createTransformer(src, filename, config, transformOptions) {
         }
     }
 
+    let mdxOptions = {}
+    if(options.mdxOptions) {
+        mdxOptions = require(path.resolve(process.cwd(), options.mdxOptions))
+    }
     const withFrontMatter = parseFrontMatter(src, options)
-    const jsx = mdx.sync(withFrontMatter)
+    const jsx = mdx.sync(withFrontMatter, {...mdxOptions, filepath: filename})
     const toTransform = `import {mdx} from '@mdx-js/react';${jsx}`
-    return process(toTransform, filename, config, transformOptions).code
+    return babelJestProcess(toTransform, filename, config, transformOptions).code
 }
 
 module.exports = {


### PR DESCRIPTION
I'd like my MDX files to behave the same way in tests as they do in prod, e.g. by running all the same remark/rehype plugins. This requires `jest-transformer-mdx` to pass the same options to `mdx.sync` as I do in prod.

I've been using [this patch](https://github.com/fracture91/ahurle-dev/blob/ef0fd642db4b70e958d85625a7a3652ae418811b/patches/jest-transformer-mdx%2B2.2.0.patch) successfully on my personal website, and [configured it like so](https://github.com/fracture91/ahurle-dev/blob/ef0fd642db4b70e958d85625a7a3652ae418811b/jest.config.js#L20-L23) to read [my shared test/prod MDX configuration](https://github.com/fracture91/ahurle-dev/blob/ef0fd642db4b70e958d85625a7a3652ae418811b/config/mdxOptions.js#L54-L70).  The config [makes it into `@next/mdx` here](https://github.com/fracture91/ahurle-dev/blob/ef0fd642db4b70e958d85625a7a3652ae418811b/next.config.js#L12-L15).  [Here's a test](https://github.com/fracture91/ahurle-dev/blob/ef0fd642db4b70e958d85625a7a3652ae418811b/__tests__/helpers/loaderTest.ts#L205-L269) that shows my plugins have the expected side effects when run through `jest-transformer-mdx`.

IIRC, the reason I provide a file path in `jest.config.js` instead of an object like `{remarkPlugins: [...], rehypePlugins: [...]}` is because the options must be JSON-serializable.  The plugins are functions, and so they can't be serialized.  `require`-ing the file later inside `createTransformer` works around that.

I'm happy to add tests/docs to cover this behavior - just wanted to make sure there's interest to merge this before I do that work.